### PR TITLE
Removed bigint dependency and changed RSA algorithm to use u128

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,3 @@ name = "codebreaker"
 
 [dependencies]
 bytemuck = "1.2"
-num-bigint = "0.3"
-
-[features]
-default = ["std"]
-std = ["num-bigint/std"]

--- a/src/cb7.rs
+++ b/src/cb7.rs
@@ -312,7 +312,7 @@ fn rsa_crypt(addr: &mut u32, val: &mut u32, rsakey: u64, modulus: u64) {
 
         while exp > 1 {
             if (exp & 1) == 1 {
-                acc = acc * base;
+                acc *= base;
                 acc %= modulus;
             }
             exp /= 2;
@@ -324,7 +324,7 @@ fn rsa_crypt(addr: &mut u32, val: &mut u32, rsakey: u64, modulus: u64) {
         // squaring the base afterwards is not necessary and may cause a
         // needless overflow.
         if exp == 1 {
-            acc = acc * base;
+            acc *= base;
         }
 
         (acc % modulus) as u64


### PR DESCRIPTION
This removes a big dependency by using Rust's available u128 for the RSA step. I checked that tests pass and the change is quite simple. Should reduce compile times quite a lot!